### PR TITLE
Initial support for playback status

### DIFF
--- a/TODO
+++ b/TODO
@@ -20,3 +20,4 @@ Some open tasks, good for getting started with the code base ;)
    crumbs for browser)
 
  * Proper config file support (see FIXME in Main.hs)
+ * Have the playback tags update whenever they change (repeat, consume etc.)

--- a/src/Macro.hs
+++ b/src/Macro.hs
@@ -49,6 +49,10 @@ macros = [
   , Macro "\3"    ":quit\n"
   , Macro "t"     ":toggle\n"
 
+  , Macro "r"     ":toggle-repeat\n"
+  , Macro "R"     ":toggle-random\n"
+  , Macro "c"     ":toggle-consume\n"
+
   , Macro "k"        ":move-up\n"
   , Macro [keyUp]    ":move-up\n"
   , Macro "j"        ":move-down\n"

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -205,13 +205,24 @@ updateStatus songWindow playWindow st = do
   where
     song = fromMaybe "none" $ fmap Song.title $ PlaybackState.currentSong st
 
-    playState = stateSymbol ++ " " ++ formatTime current ++ " / " ++ formatTime total
+    playState = stateSymbol ++ " " ++ formatTime current ++ " / " ++ formatTime total ++ " " ++ tags
       where
         (current, total) = PlaybackState.elapsedTime st
         stateSymbol = case PlaybackState.playState st of
           MPD.Playing -> "|>"
           MPD.Paused  -> "||"
           MPD.Stopped -> "[]"
+
+        tags = case filter (($ PlaybackState.playStatus st) . fst) tagList of
+          []   -> ""
+          x:xs -> "[" ++ snd x ++ concatMap ((", "++) . snd) xs ++ "]"
+
+        tagList = [
+            (MPD.stRepeat ,  "repeat")
+          , (MPD.stRandom ,  "random")
+          , (MPD.stSingle ,  "single")
+          , (MPD.stConsume, "consume")
+          ]
 
     formatTime :: Seconds -> String
     formatTime s = printf "%02d:%02d" minutes seconds

--- a/src/PlaybackState.hs
+++ b/src/PlaybackState.hs
@@ -1,4 +1,4 @@
-module PlaybackState(onChange, PlaybackState, playState, elapsedTime, currentSong) where
+module PlaybackState(onChange, PlaybackState, playState, playStatus, elapsedTime, currentSong) where
 
 import Data.Foldable (for_)
 
@@ -14,9 +14,10 @@ import           Timer (Timer)
 import qualified Timer
 
 data PlaybackState = PlaybackState {
-    playState   :: MPD.State
+    playState    :: MPD.State
+  , playStatus   :: MPD.Status
   , elapsedTime_ :: (Double, Seconds)
-  , currentSong :: Maybe MPD.Song
+  , currentSong  :: Maybe MPD.Song
 } deriving Show
 
 elapsedTime :: PlaybackState -> (Seconds, Seconds)
@@ -52,7 +53,7 @@ queryState var = do
   song   <- MPD.currentSong
 
   -- put state into var
-  let state = PlaybackState (MPD.stState status) (MPD.stTime status) song
+  let state = PlaybackState (MPD.stState status) status (MPD.stTime status) song
   liftIO $ putMVar var state
 
   -- start timer, if playing


### PR DESCRIPTION
This commit adds support for displaying playback status such as repeat, random, consume etc.

I wasn't sure whether to use a command1, eg. :random on and :random off, but I decided to use :random and :norandom instead, sort of like how :set would behave.

FIXME: The tags don't update until the playback state (not to be confused with the playback status) itself changes. I'm not sure what to touch here. Ideally they should be updated even if external programs change them, so it would have to be on some sort of server event.
