### PR TITLE
Do not assume that attr_t and chtype are long

### DIFF
--- a/ncursesw/src/Curses.chs
+++ b/ncursesw/src/Curses.chs
@@ -166,7 +166,7 @@ void nm_getmaxyx(WINDOW* win, int* y, int* x);
 -- int waddch(WINDOW *win, const chtype ch);
 {#fun unsafe waddch {id `Window', fromChar' `Char'} -> `Status' toStatus*#}
 
-fromChar' :: Char -> CULong
+fromChar' :: Char -> Chtype_t
 fromChar' = fromIntegral . ord
 
 -- int mvaddch(int y, int x, const chtype ch);

--- a/ncursesw/src/Misc.chs
+++ b/ncursesw/src/Misc.chs
@@ -68,7 +68,7 @@ fromAttr (Attr a) = a
 -}
 
 
-combine :: [Attribute] -> CULong
+combine :: [Attribute] -> Attr_t
 combine l = foldl' (.|.) 0 $ map (fromIntegral . fromEnum) l
 
 -- int wcolor_set(WINDOW *win, short color_pair_number, void* opts);
@@ -174,5 +174,5 @@ fromColor' = fromIntegral . fromColor
 -- TODO
 -- chtype getbkgd(WINDOW *win);
 
-chtypeFromAttr :: Attr -> CULong
+chtypeFromAttr :: Attr -> Chtype_t
 chtypeFromAttr = fromIntegral . fromAttr

--- a/ncursesw/src/Type.chs
+++ b/ncursesw/src/Type.chs
@@ -1,7 +1,15 @@
 module Type where
 
+import Foreign.C.Types
 import Foreign.Ptr (Ptr)
 
 #include "mycurses.h"
 
 {#pointer *WINDOW as Window newtype#}
+
+-- attr_t is an alias to chtype, which in turn is user-configurable.
+-- we need to ask c2hs to figure out which type is actually used.
+--
+-- two synonyms are used to reflect the ncurses API.
+type Attr_t   = {#type attr_t #}
+type Chtype_t = {#type chtype #}


### PR DESCRIPTION
chtype can be configured by the user, and may not be a long (e.g., on 32 bit systems).
c2hs will discover which type is actually used and generate foreign
calls accordingly.
Assuming that attr_t and chtype are long will cause type mismatches in
these cases.

This patch introduces Attr_t and Chtype_t which will point to the
correct type, discovered by c2hs at compile-time.
