### PR TITLE
Hiding volume for negative numbers

### DIFF
--- a/src/Run.hs
+++ b/src/Run.hs
@@ -135,14 +135,15 @@ updateStatus songWindow playWindow mSong status = do
     song = maybe "none" Song.title mSong
 
     playState = stateSymbol ++ " " ++ formatTime current ++ " / " ++ formatTime total
-                ++ " " ++ volume
+                ++ (if stVol >= 0 then " " ++ volume else "")
       where
         (current, total) = PlaybackState.elapsedTime status
         stateSymbol = case MPD.stState status of
           MPD.Playing -> "|>"
           MPD.Paused  -> "||"
           MPD.Stopped -> "[]"
-        volume = "vol: " ++ show (MPD.stVolume status)
+        volume = "vol: " ++ show stVol
+        stVol  = MPD.stVolume status
 
     tags = intercalate ", " . map snd . filter (($ status) . fst) $ tagList
 


### PR DESCRIPTION
This fixes a bug where mixer-less devices display as “vol: -1”
