### PR TITLE
Re-fixed negative volume issue

### DIFF
--- a/src/Run.hs
+++ b/src/Run.hs
@@ -146,8 +146,8 @@ updateStatus songWindow playWindow mSong status = do
         -- if an audio output does not support volume control, volume is -1, in
         -- that cases we do not show it
         volume
-          | 0 < stVol = ""
-          | otherwise = "vol: " ++ show stVol
+          | stVol < 0 = ""
+          | otherwise = " vol: " ++ show stVol
           where
             stVol  = MPD.stVolume status
 


### PR DESCRIPTION
Two issues:
1. Missing space before "vol: " when volume does get displayed
2. The condition was incorrect; volume should be hidden for vol < 0, not 0 < vol.
