### PR TITLE
Fixed update behavior for the browser widget

### DIFF
--- a/src/Content.hs
+++ b/src/Content.hs
@@ -26,7 +26,7 @@ data Content =
   | Song MPD.Song
   | PList MPD.PlaylistName
   | PListSong MPD.PlaylistName Int MPD.Song
-  deriving Show
+  deriving (Show, Eq)
 
 toContent :: MPD.LsResult -> Content
 toContent r = case r of

--- a/src/Widget/ListWidget.hs
+++ b/src/Widget/ListWidget.hs
@@ -27,6 +27,7 @@ module Widget.ListWidget (
 , Widget.ListWidget.searchItem
 , Widget.ListWidget.filterItem
 , Widget.ListWidget.handleEvent
+, Widget.ListWidget.tryMatch
 
 #ifdef TEST
 
@@ -117,7 +118,7 @@ resize widget size = result {getParent = (`resize` size) `fmap` getParent result
 update :: ListWidget a -> [a] -> ListWidget a
 update widget list = setPosition newWidget $ getPosition widget
   where
-    newWidget       = widget { getList = list, getListLength = length list }
+    newWidget = widget { getList = list, getListLength = length list, getParent = Nothing }
 
 ------------------------------------------------------------------------
 -- search
@@ -168,6 +169,9 @@ findFirst predicate list = case matches of
 searchItem :: Searchable a => ListWidget a -> SearchOrder -> String -> ListWidget a
 searchItem w Forward  t = searchForward  (searchPredicate t) w
 searchItem w Backward t = searchBackward (searchPredicate t) w
+
+tryMatch :: Eq a => ListWidget a -> a -> Maybe (ListWidget a)
+tryMatch lw c = setPosition lw `fmap` findFirst (==c) (zip [0..] $ getList lw)
 
 data SearchPredicate = Search | Filter
 


### PR DESCRIPTION
Current behavior: Extract the current breadcrumbs list from the Browser
widget, then recursively try to browse inwards, halting on failure (eg.
removed item during update)
