### PR TITLE
Add support for dG and dgg commands from Vim

### DIFF
--- a/resource/default-mappings
+++ b/resource/default-mappings
@@ -40,7 +40,9 @@ map 4           :window-search<CR>
 # playback
 map <CR>        :default-action<CR>
 map t           :toggle<CR>
-map d           :remove<CR>
+map dd          :remove<CR>
+map dgg         :remove-above<CR>
+map dG          :remove-below<CR>
 map y           :copy<CR>
 map p           :paste<CR>
 map P           :paste-prev<CR>

--- a/src/Command.hs
+++ b/src/Command.hs
@@ -15,6 +15,7 @@ module Command (
 
 import           Data.List
 import           Data.Char
+import           Data.Maybe (catMaybes)
 import           Control.Monad (void, when, unless, guard)
 import           Control.Applicative
 import           Data.Foldable (forM_)
@@ -107,6 +108,14 @@ instance Widget PlaylistWidget where
       forM_ (ListWidget.select l >>= MPD.sgId) MPD.deleteId
       return l
 
+    EvRemoveAbove -> do
+      forM_ (catMaybes $ MPD.sgId <$> ListWidget.aboveSelected l) MPD.deleteId
+      return $ ListWidget.setPosition l 0
+
+    EvRemoveBelow -> do
+      forM_ (catMaybes $ MPD.sgId <$> ListWidget.belowSelected l) MPD.deleteId
+      return l
+
     EvPaste -> do
       let n = succ (ListWidget.getPosition l)
       mPath <- gets copyRegister
@@ -141,6 +150,8 @@ instance Widget PlaylistWidget where
         EvMoveLast             -> currentTime
         EvScroll _             -> currentTime
         EvRemove               -> currentTime
+        EvRemoveAbove          -> currentTime
+        EvRemoveBelow          -> currentTime
         EvPaste                -> currentTime
         EvPastePrevious        -> currentTime
 
@@ -386,6 +397,12 @@ commands = [
   -- Remove current song from playlist
   , command "remove" "remove the song under the cursor from the playlist" $
       sendEventCurrent EvRemove
+
+  , command "remove-above" "remove songs above the selected song (included) from the playlist" $
+      sendEventCurrent EvRemoveAbove
+
+  , command "remove-below" "remove songs below the selected song (included) from the playlist" $
+      sendEventCurrent EvRemoveBelow
 
   , command "paste" "add the last deleted song after the selected song in the playlist" $
       sendEventCurrent EvPaste

--- a/src/Vimus.hs
+++ b/src/Vimus.hs
@@ -127,6 +127,8 @@ data Event =
   | EvMoveLast
   | EvScroll Int
   | EvRemove
+  | EvRemoveAbove
+  | EvRemoveBelow
   | EvPaste
   | EvPastePrevious
   | EvLogMessage      -- ^ emitted when a message is added to the log

--- a/src/Widget/ListWidget.hs
+++ b/src/Widget/ListWidget.hs
@@ -7,6 +7,8 @@ module Widget.ListWidget (
 -- * current element
 , getPosition
 , select
+, aboveSelected
+, belowSelected
 , breadcrumbs
 
 -- * movement
@@ -222,6 +224,16 @@ select :: ListWidget a -> Maybe a
 select l
   | getLength l == 0 = Nothing
   | otherwise        = Just (getElements l !! getPosition l)
+
+aboveSelected :: ListWidget a -> [a]
+aboveSelected l
+  | getLength l == 0 = []
+  | otherwise        = take (getPosition l + 1) $ getElements l
+
+belowSelected :: ListWidget a -> [a]
+belowSelected l
+  | getLength l == 0 = []
+  | otherwise        = drop (getPosition l) $ getElements l
 
 setMarked :: ListWidget a -> Maybe Int -> ListWidget a
 setMarked w x = w { getMarked = x }


### PR DESCRIPTION
"dG" and "dgg" are respectively associated to "remove-below" and
"remove-above" commands.

Note that "d" command has been re-mapped to "dd" in the default key
mapping file to avoid the common prefix with "dG" and "dgg". If you really
want to restore the old key mapping, use your own mapping file.
