### PR TITLE
Autocompletion that cycles through alternatives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /dist/
 /ncursesw/dist/
+/.cabal-sandbox
+/cabal.sandbox.config


### PR DESCRIPTION
Mimics Vim behavior, except it appends a space if
the command can be completed unambiguously, for some reason.

Algorithm is as follows:
- Suppose user has typed "foo" (so '^' is the cursor position):
  
  ```
  :foo
      ^
  ```
- Then user presses <TAB>:
  
  ```
  :foo         foobar   foobaz
      ^
  ```
- Then user presses <TAB> once more:
  
  ```
  :foobar      foobar   foobaz
         ^
  ```
- And again:
  
  ```
  :foobaz      foobar   foobaz
         ^
  ```
- Next <TAB> press will return her to the start:
  
  ```
  :foo         foobar   foobaz
      ^
  ```
- And then the cycle will repeat
