### PR TITLE
ncursesw: add type alias for wint_t

### DIFF
--- a/ncursesw/src/CursesInput.chs
+++ b/ncursesw/src/CursesInput.chs
@@ -72,5 +72,5 @@ int keyF(int n);
 wget_wch :: Window -> IO Char
 wget_wch window =  fmap snd $ wget_wch_ window
 
-peekChar :: Ptr CUInt -> IO Char
+peekChar :: Ptr Wint_t -> IO Char
 peekChar = fmap (chr . fromIntegral) . peek

--- a/ncursesw/src/UI/Curses/Type.chs
+++ b/ncursesw/src/UI/Curses/Type.chs
@@ -7,9 +7,11 @@ import Foreign.Ptr (Ptr)
 
 {#pointer *WINDOW as Window newtype#}
 
--- attr_t is an alias to chtype, which in turn is user-configurable.
--- we need to ask c2hs to figure out which type is actually used.
---
--- two synonyms are used to reflect the ncurses API.
+{-
+Wrapper types that reflect typedef'd values on the C side so
+as to avoid making assumptions about what their underlying types
+are (e.g. the type of chtype is user-configurable).
+-}
 type Attr_t   = {#type attr_t #}
 type Chtype_t = {#type chtype #}
+type Wint_t   = {#type wint_t #}


### PR DESCRIPTION
On the C side, `wint_t' is a typedef used by
many of the wide char curses operations.
Previously, the binding assumed that`wint_t' is
an unsigned int.
Issue #53 indicates that the assumption about the
underlying type of `wint_t' may not hold
(the user experiences a build failure because
`CInt' is provided where `CUInt' is expected).

Perusal of curses.h indicates that `wint_t'
should be unsigned int or not defined at all.
Nevertheless, to work around the issue, this patch
introduces a corresponding type alias`Wint_t' on
the Haskell side which is set to the appropriate
type by c2hs at compile time.
