### PR TITLE
Building with GHC 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /dist/
 /ncursesw/dist/
+/.stack-work/
+tags

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,3 @@
+resolver: lts-8.11
+extra-deps:
+- wcwidth-0.0.2


### PR DESCRIPTION
Added a _stack.yaml_ with the current stable resolver, thereby using GHC 8.0.2. The usual mess of warnings about unnecessary imports results, but it builds fine.

AfC