### PR TITLE
Expose play and pause commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /dist/
 /ncursesw/dist/
+/.stack-work/
+tags

--- a/src/Vimus/Command.hs
+++ b/src/Vimus/Command.hs
@@ -488,6 +488,12 @@ commands = [
   , command "set-library-path" "While MPD knows where your songs are stored, vimus doesn't. If you want to use the *%* feature of the command :! you need to tell vimus where your songs are stored." $ do
       \(Path p) -> setLibraryPath p
 
+  , command "play" "start or continue playing" $ do
+      MPD.play Nothing :: Vimus ()
+
+  , command "pause" "pause playback" $ do
+      MPD.pause True :: Vimus ()
+
   , command "next" "play the next song" $ do
       MPD.next :: Vimus ()
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,3 @@
+resolver: lts-8.11
+extra-deps:
+- wcwidth-0.0.2


### PR DESCRIPTION
I constantly found myself typing `:play` and `:pause` trying to get it to do just that. I was surprised that ex commands by those names were not exposed since _mpc(1)_ has those as commands. Digging into *libmpd-haskell* I discovered that you already had those bound, just not exposed at the UI (presumably because `:toggle` covers it generically.

This patch simply exposes those existing MPD commands as vimus ex commands.