### PR TITLE
Enable Spacebar to be used to toggle playback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /dist/
 /ncursesw/dist/
+/.stack-work/
+tags

--- a/resource/default-mappings
+++ b/resource/default-mappings
@@ -44,6 +44,7 @@ map 4           :window-search<CR>
 # playback
 map <CR>        :default-action<CR>
 map t           :toggle<CR>
+map <Space>     :toggle<CR>
 map d           :remove<CR>
 map y           :copy<CR>
 map p           :paste<CR>

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,3 @@
+resolver: lts-8.11
+extra-deps:
+- wcwidth-0.0.2


### PR DESCRIPTION
In addition to wanting `:play` and `:pause` exposed (see #84 ), I find myself constantly hitting **Space** and wondering why nothing is happening. Toggle is there, yes, with **t** as a binding, but I find that a bit un-memorable; most GUI players I use react to spacebar as a play/pause toggle.

Discovered that you support multiple bindings without breaking things, so added `<Space>` as a binding to `:toggle` in the default keybinding map.

Hope you'll consider accepting this.