### PR TITLE
Display filename for tracks with unknown titles

### DIFF
--- a/src/Vimus/Song.hs
+++ b/src/Vimus/Song.hs
@@ -5,6 +5,7 @@ module Vimus.Song (
 , artist
 , title
 , track
+, filename
 ) where
 
 import           Data.List (intercalate)

--- a/src/Vimus/Song/Format.hs
+++ b/src/Vimus/Song/Format.hs
@@ -66,7 +66,7 @@ instance Default SongFormat where
       (orNone $ artist song)
       (orNone $ album song)
       (orNone $ track song)
-      (orNone $ title song)
+      (orNone $ title song <|> filename song)
    where
     orNone = fromMaybe "(none)"
 


### PR DESCRIPTION
This solves the annoying `(none) - (none) - (none) - (none)` issue for
untagged files by giving you a (generally useful) filename instead.