### PR TITLE
GHC 8 compatibility

### DIFF
--- a/src/Vimus/Widget/Type.hs
+++ b/src/Vimus/Widget/Type.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE TypeSynonymInstances, FlexibleInstances, TypeFamilies #-}
+{-# LANGUAGE TypeSynonymInstances, FlexibleInstances, TypeFamilies, CPP #-}
 module Vimus.Widget.Type where
 
 import           Data.String
@@ -32,6 +32,11 @@ toPlainText = concatMap unChunk . unTextLine
 instance Monoid TextLine where
   mempty          = TextLine []
   xs `mappend` ys = TextLine (unTextLine xs ++ unTextLine ys)
+
+#if MIN_VERSION_base(4,9,0)
+instance Semigroup TextLine where
+  TextLine xs <> TextLine ys = TextLine (xs ++ ys)
+#endif
 
 instance IsString TextLine where
   fromString = TextLine . return . fromString

--- a/test/Vimus/RenderSpec.hs
+++ b/test/Vimus/RenderSpec.hs
@@ -1,7 +1,7 @@
 module Vimus.RenderSpec (main, spec) where
 
 import           Test.Hspec
-import           Test.QuickCheck
+import           Test.QuickCheck hiding (UnicodeString)
 import           Control.Applicative
 
 import           Vimus.Render


### PR DESCRIPTION
Semigroup is now a superclass of Monoid, so we need to add a new
instance for it.

We guard the Semigroup instance to avoid depending on `semigroups` for
older GHC.