### PR TITLE
Update to work with containers-0.6

### DIFF
--- a/src/Vimus/Command.hs
+++ b/src/Vimus/Command.hs
@@ -28,8 +28,8 @@ import           System.Process (system)
 
 import           System.Directory (doesFileExist)
 import           System.FilePath ((</>), dropFileName)
-import           Data.Map (Map, (!))
-import qualified Data.Map as Map
+import           Data.Map.Strict (Map, (!))
+import qualified Data.Map.Strict as Map
 
 import           Data.Time.Clock.POSIX
 
@@ -679,7 +679,7 @@ eval input = case parseCommand input of
 -- Actions with the same command name are combined with (<|>).
 commandMap :: Map String VimusAction
 commandMap = foldr f Map.empty commands
-  where f c = Map.insertWith' (<|>) (commandName c) (commandAction c)
+  where f c = Map.insertWith (<|>) (commandName c) (commandAction c)
 
 commandNames :: [String]
 commandNames = Map.keys commandMap

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,1 @@
-resolver: lts-8.11
-extra-deps:
-- wcwidth-0.0.2
+resolver: lts-13.12

--- a/vimus.cabal
+++ b/vimus.cabal
@@ -1,5 +1,5 @@
 name:             vimus
-version:          0.2.1
+version:          0.2.1.1
 synopsis:         An MPD client with vim-like key bindings
 description:      An MPD client with vim-like key bindings
                   .
@@ -43,7 +43,7 @@ library
     , wcwidth
     , libmpd == 0.9.*
     , mtl >= 2
-    , containers >= 0.4 && < 0.6
+    , containers >= 0.5 && < 0.7
     , deepseq
     , time
     , old-locale


### PR DESCRIPTION
The most recent **containers** major version has taken a number of  deprecated functions out completely. This patch changes the functions and module names to that recommended by the deprecation error messages. Bumps lower bound of **containers** to `0.5`, appears to be the first to introduce Data.Map.Strict (the actual lower bound is probably higher).