### PR TITLE
Add MonadFail instance

### DIFF
--- a/src/Vimus/Command/Parser.hs
+++ b/src/Vimus/Command/Parser.hs
@@ -40,9 +40,11 @@ instance Applicative Parser where
   (<*>) = ap
 
 instance Monad Parser where
-  fail      = parserFail . ParseError
   return a  = Parser $ \input -> Right (a, input)
   p1 >>= p2 = Parser $ \input -> runParser p1 input >>= uncurry (runParser . p2)
+
+instance MonadFail Parser where
+  fail      = parserFail . ParseError
 
 instance Alternative Parser where
   empty = parserFail Empty

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-13.12
+resolver: lts-15.8


### PR DESCRIPTION
In order to build on GHC 8.8.3 (via Stackage snapshot `lts-15.8`) there needed to be a MonadFail instance for the Parser monad, and (more's the point) the `fail` method needed to be moved out of the Monad instance. Changed.

AfC